### PR TITLE
Add Stream Deck Mobile to Chat Pager

### DIFF
--- a/streamdeck-chatpager/AlertManager.cs
+++ b/streamdeck-chatpager/AlertManager.cs
@@ -137,6 +137,7 @@ namespace ChatPager
             switch (connection.DeviceInfo().Type)
             {
                 case StreamDeckDeviceType.StreamDeckClassic:
+                case StreamDeckDeviceType.StreamDeckMobile:
                     await connection.SwitchProfileAsync("FullScreenAlert");
                     break;
                 case StreamDeckDeviceType.StreamDeckMini:
@@ -234,6 +235,7 @@ namespace ChatPager
             switch (connection.DeviceInfo().Type)
             {
                 case StreamDeckDeviceType.StreamDeckClassic:
+                case StreamDeckDeviceType.StreamDeckMobile:
                     await connection.SwitchProfileAsync("FullScreenAlert");
                     break;
                 case StreamDeckDeviceType.StreamDeckMini:
@@ -302,6 +304,7 @@ namespace ChatPager
             switch (connection.DeviceInfo().Type)
             {
                 case StreamDeckDeviceType.StreamDeckClassic:
+                case StreamDeckDeviceType.StreamDeckMobile:
                     await connection.SwitchProfileAsync("FullScreenAlert");
                     break;
                 case StreamDeckDeviceType.StreamDeckMini:

--- a/streamdeck-chatpager/manifest.json
+++ b/streamdeck-chatpager/manifest.json
@@ -184,6 +184,12 @@
       "ReadOnly": true,
       "DeviceType": 2,
       "DontAutoSwitchWhenInstalled": true
+    },
+    {
+      "Name": "FullScreenAlertMobile",
+      "ReadOnly": true,
+      "DeviceType": 3,
+      "DontAutoSwitchWhenInstalled": true
     }
   ],
   "SDKVersion": 2,


### PR DESCRIPTION
I added the deviceType & cases to the alert for StreamDeck Mobile which should be handled the same as SD Classic in these situations.

These are untested.