### PR TITLE
Fixed Live Streamers with non-standard characters.

### DIFF
--- a/streamdeck-chatpager/Actions/AlertFlasher.cs
+++ b/streamdeck-chatpager/Actions/AlertFlasher.cs
@@ -246,7 +246,7 @@ namespace ChatPager
                 {
                     await DrawStreamerImage(streamerInfo, image);
                 }
-                channelName = streamerInfo?.UserDisplayName;
+                channelName = streamerInfo?.UserName;
             }
         }
 

--- a/streamdeck-chatpager/TwitchTools.csproj
+++ b/streamdeck-chatpager/TwitchTools.csproj
@@ -37,7 +37,7 @@
     <OutputPath>bin\Release\com.barraider.twitchtools.sdplugin\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.41" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="NAudio" Version="2.0.1" />
     <PackageReference Include="StreamDeck-Tools" Version="3.2.0" />

--- a/streamdeck-chatpager/Wrappers/TwitchChannelInfo.cs
+++ b/streamdeck-chatpager/Wrappers/TwitchChannelInfo.cs
@@ -15,6 +15,9 @@ namespace ChatPager.Wrappers
         [JsonProperty(PropertyName = "user_id")]
         public string UserId { get; private set; }
 
+        [JsonProperty(PropertyName = "user_login")]
+        public string UserName { get; private set; }
+
         [JsonProperty(PropertyName = "user_name")]
         public string UserDisplayName { get; private set; }
 

--- a/streamdeck-chatpager/manifest.json
+++ b/streamdeck-chatpager/manifest.json
@@ -201,7 +201,7 @@
   "Name": "Twitch Tools",
   "Icon": "Images/pluginIcon",
   "URL": "https://BarRaider.com/",
-  "Version": "2.8",
+  "Version": "2.9",
   "DefaultWindowSize": [ 620, 750 ],
   "CodePath": "com.barraider.twitchtools",
   "Category": "Twitch Tools [BarRaider]",


### PR DESCRIPTION
- Fixed issue where `Live Streamers` would fail to Join/Host/Raid if the Channel's name had non-standard characters.