### PR TITLE
Upgrade TwitchLib.PubSub and move to a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "TwitchLib.PubSub"]
+	path = TwitchLib.PubSub
+	url = https://github.com/TwitchLib/TwitchLib.PubSub

--- a/streamdeck-chatpager.sln
+++ b/streamdeck-chatpager.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.29905.134
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchTools", "streamdeck-chatpager\TwitchTools.csproj", "{D4609600-2469-47DC-A7C0-5D654E708BD3}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchLib.PubSub", "..\TwitchLib.PubSub\TwitchLib.PubSub\TwitchLib.PubSub.csproj", "{6F2F830D-E7E0-4592-BB05-6BF56382079F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchLib.PubSub", "TwitchLib.PubSub\TwitchLib.PubSub\TwitchLib.PubSub.csproj", "{6F2F830D-E7E0-4592-BB05-6BF56382079F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/streamdeck-chatpager/TwitchTools.csproj
+++ b/streamdeck-chatpager/TwitchTools.csproj
@@ -61,7 +61,7 @@
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="TwitchLib.PubSub">
-      <HintPath>..\..\TwitchLib.PubSub\TwitchLib.PubSub\bin\Release\netstandard2.0\TwitchLib.PubSub.dll</HintPath>
+      <HintPath>..\TwitchLib.PubSub\TwitchLib.PubSub\bin\Release\netstandard2.0\TwitchLib.PubSub.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This upgrades `TwitchLib.PubSub` to the latest version, as well as moving it to a git submodule instead of an external dependency.

This upgrade fixes the following warnings shown during build:

```
streamdeck-chatpager\Twitch\TwitchPubSubManager.cs(133,13,133,36): warning CS0618: 'TwitchPubSub.OnRewardRedeemed' is obsolete: 'This event fires on an undocumented/retired/obsolete topic. Consider using OnChannelPointsRewardRedeemed'
streamdeck-chatpager\Twitch\TwitchPubSubManager.cs(157,13,157,36): warning CS0618: 'TwitchPubSub.OnRewardRedeemed' is obsolete: 'This event fires on an undocumented/retired/obsolete topic. Consider using OnChannelPointsRewardRedeemed'
streamdeck-chatpager\Twitch\TwitchPubSubManager.cs(210,13,210,51): warning CS0618: 'TwitchPubSub.ListenToBitsEvents(string)' is obsolete: 'This topic is deprecated by Twitch. Please use ListenToBitsEventsV2()'
streamdeck-chatpager\Twitch\TwitchPubSubManager.cs(213,13,213,48): warning CS0618: 'TwitchPubSub.ListenToRewards(string)' is obsolete: 'This method listens to an undocumented/retired/obsolete topic. Consider using ListenToChannelPoints()'
```